### PR TITLE
[refactor] Remove helpers from data model

### DIFF
--- a/lib/models/functions.js
+++ b/lib/models/functions.js
@@ -26,13 +26,15 @@ class BaseFunction extends EmbeddedDocumentModel {
 
 class Function extends BaseFunction {
   constructor(doc) {
+    _.remove(doc.unknown || [], { tagName: '@function' });
+
     super(doc);
 
     this.exportType = extractExportType(doc);
   }
 
   static detect(doc) {
-    return doc.kind === 'function' || (_.remove(doc.unknown || [], { tagName: '@function' }).length > 0);
+    return doc.kind === 'function' || (_.find(doc.unknown || [], { tagName: '@function' }));
   }
 }
 
@@ -49,10 +51,4 @@ class Method extends BaseFunction {
   }
 }
 
-class Helper extends Function {
-  static detect(doc) {
-    return super.detect(doc) && doc.memberof.match(/helpers\//) !== null;
-  }
-}
-
-module.exports = { Function, Method, Helper };
+module.exports = { Function, Method };

--- a/lib/models/module.js
+++ b/lib/models/module.js
@@ -7,7 +7,6 @@ class Module {
     // Attributes
     this.file = doc.name;
     this.functions = [];
-    this.helpers = [];
     this.variables = [];
 
     // Relationships

--- a/lib/preprocessors/generate-esdoc-jsonapi.js
+++ b/lib/preprocessors/generate-esdoc-jsonapi.js
@@ -10,7 +10,6 @@ const Component = require('../models/classes').Component;
 
 const Function = require('../models/functions').Function;
 const Method = require('../models/functions').Method;
-const Helper = require('../models/functions').Helper;
 
 const Variable = require('../models/variables').Variable;
 const Field = require('../models/variables').Field;
@@ -68,9 +67,6 @@ module.exports = function generateESDocJsonApi(inputPath) {
         let klass = new Class(doc)
         module.classes.push(klass);
         klasses[klass.id] = klass;
-
-      } else if (Helper.detect(doc)) {
-        module.helpers.push(new Helper(doc));
 
       } else if (Function.detect(doc)) {
         module.functions.push(new Function(doc));

--- a/node-tests/fixtures/basic-class/output.json
+++ b/node-tests/fixtures/basic-class/output.json
@@ -9,7 +9,6 @@
       "attributes": {
         "file": "foo",
         "functions": [],
-        "helpers": [],
         "variables": []
       },
       "relationships": {

--- a/node-tests/fixtures/basic-component/output.json
+++ b/node-tests/fixtures/basic-component/output.json
@@ -9,7 +9,6 @@
       "attributes": {
         "file": "components/foo",
         "functions": [],
-        "helpers": [],
         "variables": []
       },
       "relationships": {

--- a/node-tests/fixtures/basic-module/output.json
+++ b/node-tests/fixtures/basic-module/output.json
@@ -50,12 +50,7 @@
             "description": "",
             "lineNumber": 21,
             "access": "public",
-            "tags": [
-              {
-                "name": "function",
-                "value": "bar"
-              }
-            ],
+            "tags": [],
             "file": "foo",
             "returns": {
               "type": "Array<boolean>",
@@ -92,9 +87,19 @@
             "isAsync": false,
             "isGenerator": true,
             "exportType": "named"
+          },
+          {
+            "access": "public",
+            "description": "",
+            "exportType": "named",
+            "file": "foo",
+            "lineNumber": 63,
+            "name": "garply",
+            "params": [],
+            "returns": null,
+            "tags": []
           }
         ],
-        "helpers": [],
         "variables": [
           {
             "name": "baz",
@@ -120,16 +125,6 @@
             "name": "quux",
             "description": "",
             "lineNumber": 35,
-            "access": "public",
-            "tags": [],
-            "file": "foo",
-            "type": "any",
-            "exportType": "named"
-          },
-          {
-            "name": "garply",
-            "description": "",
-            "lineNumber": 63,
             "access": "public",
             "tags": [],
             "file": "foo",

--- a/node-tests/fixtures/helper-module/output.json
+++ b/node-tests/fixtures/helper-module/output.json
@@ -8,19 +8,13 @@
       "id": "helpers/foo",
       "attributes": {
         "file": "helpers/foo",
-        "functions": [],
-        "helpers": [
+        "functions": [
           {
             "name": "helper",
             "description": "",
             "lineNumber": 7,
             "access": "public",
-            "tags": [
-              {
-                "name": "function",
-                "value": "helper"
-              }
-            ],
+            "tags": [],
             "file": "helpers/foo",
             "returns": {
               "type": "string",


### PR DESCRIPTION
Helpers turned out to be less unique than originally thought. This PR
removes the simplistic notion of helpers and leaves it to the API docs
themselves to determine what the helper in a module is (class, function,
etc).