### PR TITLE
@type decorator with new lines -> Cannot read property '1' of null

### DIFF
--- a/lib/models/utils/type.js
+++ b/lib/models/utils/type.js
@@ -18,7 +18,7 @@ function extractDecoratorType(decorator) {
   // we should work on this to make it better
   if (decorator && decorator.arguments) {
     // remove quotes and surrounding parens
-    return decorator.arguments.replace(/['"]/g, '').match(/^\((.*)\)$/)[1];
+    return decorator.arguments.replace(/['"]/g, '').match(/^\(([\s\S]*)\)$/)[1];
   }
 }
 


### PR DESCRIPTION
`.*` matches any character except newline
`[\s\S]*` matches whitespace or not whitespace, i.e any character

This allows the addon to work with decorators that specify the type using multiple lines. E.g:

```js
@type(optional(
  unionOf(
    arrayOf('object'),
    shapeOf({ then: Function })
  )
))
data;
```

The previous regex would break because there would be no matches, return null and hence `Cannot read property '1' of null`.

Like you say in the comments, ideally we would make a better parsing of the types, but at least this allows the docs to build.