### PR TITLE
feat: primitive TypeScript support

### DIFF
--- a/lib/broccoli/generator.js
+++ b/lib/broccoli/generator.js
@@ -9,7 +9,7 @@ const generateESDocJsonApi = require('../preprocessors/generate-esdoc-jsonapi');
 module.exports = class DocsGenerator extends CachingWriter {
   constructor(inputNodes, options) {
     let defaults = {
-      cacheInclude: [/\.js$/]
+      cacheInclude: [/\.(?:js|ts)$/]
     };
 
     super(inputNodes, Object.assign(defaults, options));

--- a/lib/preprocessors/generate-esdoc-jsonapi.js
+++ b/lib/preprocessors/generate-esdoc-jsonapi.js
@@ -20,11 +20,11 @@ const Serializer = require('../serializers/main');
 
 function normalizePaths(doc) {
   if (doc.kind === 'file') {
-    doc.name = doc.name ? doc.name.substr(doc.name.indexOf('/') + 1).replace(/(\/index)?\.js/, '') : undefined;
+    doc.name = doc.name ? doc.name.substr(doc.name.indexOf('/') + 1).replace(/(\/index)?\.(?:js|ts)/, '') : undefined;
   } else {
-    doc.longname = doc.longname ? doc.longname.substr(doc.longname.indexOf('/') + 1).replace(/(\/index)?\.js/, '') : undefined;
-    doc.memberof = doc.memberof ? doc.memberof.substr(doc.memberof.indexOf('/') + 1).replace(/(\/index)?\.js/, '') : undefined;
-    doc.importPath = doc.importPath ? doc.importPath.substr(doc.importPath.indexOf('/') + 1).replace(/(\/index)?\.js/, '') : undefined;
+    doc.longname = doc.longname ? doc.longname.substr(doc.longname.indexOf('/') + 1).replace(/(\/index)?\.(?:js|ts)/, '') : undefined;
+    doc.memberof = doc.memberof ? doc.memberof.substr(doc.memberof.indexOf('/') + 1).replace(/(\/index)?\.(?:js|ts)/, '') : undefined;
+    doc.importPath = doc.importPath ? doc.importPath.substr(doc.importPath.indexOf('/') + 1).replace(/(\/index)?\.(?:js|ts)/, '') : undefined;
   }
 }
 

--- a/lib/preprocessors/generate-esdoc.js
+++ b/lib/preprocessors/generate-esdoc.js
@@ -7,6 +7,7 @@ const tmp = require('tmp');
 
 const ESDOC_CONFIG = {
   source: './',
+  includes: ['\\.(?:js|ts)$'],
   plugins: [
     {
       name: 'esdoc-ecmascript-proposal-plugin',
@@ -22,7 +23,8 @@ const ESDOC_CONFIG = {
         dynamicImport: true
       }
     },
-    { name: 'esdoc-accessor-plugin' }
+    { name: 'esdoc-accessor-plugin' },
+    { name: 'esdoc-typescript-plugin', option: { enable: true } }
   ]
 };
 
@@ -67,4 +69,4 @@ module.exports = function generateESDoc(inputPath) {
 
     throw e;
   }
-}
+};

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "esdoc": "pzuraq/esdoc#015a342",
     "esdoc-accessor-plugin": "^1.0.0",
     "esdoc-ecmascript-proposal-plugin": "^1.0.0",
+    "esdoc-typescript-plugin": "^1.0.1",
     "fs-extra": "^5.0.0",
     "json-api-serializer": "^1.11.0",
     "lodash": "^4.17.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2679,6 +2679,13 @@ esdoc-ecmascript-proposal-plugin@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/esdoc-ecmascript-proposal-plugin/-/esdoc-ecmascript-proposal-plugin-1.0.0.tgz#390dc5656ba8a2830e39dba3570d79138df2ffd9"
 
+esdoc-typescript-plugin@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/esdoc-typescript-plugin/-/esdoc-typescript-plugin-1.0.1.tgz#d4b929677f2ee5587a86ec70e766537040b98662"
+  integrity sha512-QV9rdis5PkypVK1fh2wuESZPQZUVjTwt4hj97Pivb9M8wGPMOTxYu5ofkyGWm3xgNL+K0VxZY6TGEO07kfGAtg==
+  dependencies:
+    typescript "^2.8.3"
+
 esdoc@pzuraq/esdoc#015a342:
   version "1.0.4"
   resolved "https://codeload.github.com/pzuraq/esdoc/tar.gz/015a3426b2e53b2b0270a9c00133780db3f1d144"
@@ -6634,6 +6641,11 @@ type-is@~1.6.15:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+typescript@^2.8.3:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
+  integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
This PR enables primitive TypeScript support by:

- processing `.js` _and_ `.ts` files
- adding [`esdoc-typescript-plugin`](https://github.com/esdoc/esdoc-plugins/tree/master/esdoc-typescript-plugin)

This solution is not perfect, but _good enough_ to at least enable documenting TypeScript code, until [`ember-cli-addon-docs-typedoc`](https://github.com/typed-ember/ember-cli-addon-docs-typedoc) is or `ember-cli-addon-docs-tsdoc` are a real thing.